### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/src/Zip.php
+++ b/src/Zip.php
@@ -131,10 +131,10 @@ class Zip implements ExtractableInterface
 
 		foreach ($files as $file)
 		{
-			$this->addToZIPFile($file, $contents, $ctrldir);
+			$this->addToZipFile($file, $contents, $ctrldir);
 		}
 
-		return $this->createZIPFile($contents, $ctrldir, $archive);
+		return $this->createZipFile($contents, $ctrldir, $archive);
 	}
 
 	/**
@@ -482,7 +482,7 @@ class Zip implements ExtractableInterface
 	 *
 	 * @since   1.0
 	 */
-	protected function unix2DOSTime($unixtime = null)
+	protected function unix2DosTime($unixtime = null)
 	{
 		$timearray = (is_null($unixtime)) ? getdate() : getdate($unixtime);
 
@@ -512,7 +512,7 @@ class Zip implements ExtractableInterface
 	 * @since   1.0
 	 * @todo    Review and finish implementation
 	 */
-	private function addToZIPFile(array &$file, array &$contents, array &$ctrldir)
+	private function addToZipFile(array &$file, array &$contents, array &$ctrldir)
 	{
 		$data = &$file['data'];
 		$name = str_replace('\\', '/', $file['name']);
@@ -622,7 +622,7 @@ class Zip implements ExtractableInterface
 	 * @since   1.0
 	 * @todo	Review and finish implementation
 	 */
-	private function createZIPFile(array &$contents, array &$ctrlDir, $path)
+	private function createZipFile(array &$contents, array &$ctrlDir, $path)
 	{
 		$data = implode('', $contents);
 		$dir = implode('', $ctrlDir);


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.