### PR TITLE
Add additional param to the unknown archive exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         }
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-2.0-dev": "2.0-dev"

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,0 +1,10 @@
+## Updating from v1 to v2
+
+### Minimum supported PHP version raised
+
+All Framework packages now require PHP 7.2 or newer.
+
+### Exception Class Constructors
+`Joomla\Archive\Exception\UnsupportedArchiveException` now requires an additional constructor argument. `$adapterType`
+which contains the adapter that can't be matched to a valid parser. This comes with a matching argument `getUnsupportedAdapterType`
+in the exception, which can be used to create localised error messages to display to users.

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -173,16 +173,14 @@ class Archive
 	{
 		if ($override || !isset($this->adapters[$type]))
 		{
-			$error = !\is_object($class) && !class_exists($class) ? 'Archive adapter "%s" (class "%s") not found.' : '';
-
 			if (!\is_object($class) && !class_exists($class))
 			{
-				throw new UnsupportedArchiveException(sprintf('Archive adapter "%s" (class "%s") not found.', $type, $class));
+				throw new UnsupportedArchiveException($type, sprintf('Archive adapter "%s" (class "%s") not found.', $type, $class));
 			}
 
 			if (!$class::isSupported())
 			{
-				throw new UnsupportedArchiveException(sprintf('Archive adapter "%s" (class "%s") not supported.', $type, $class));
+				throw new UnsupportedArchiveException($type, sprintf('Archive adapter "%s" (class "%s") not supported.', $type, $class));
 			}
 
 			$object = new $class($this->options);
@@ -190,6 +188,7 @@ class Archive
 			if (!($object instanceof ExtractableInterface))
 			{
 				throw new UnsupportedArchiveException(
+					$type,
 					sprintf(
 						'The provided adapter "%s" (class "%s") must implement %s',
 						$type,

--- a/src/Exception/UnknownArchiveException.php
+++ b/src/Exception/UnknownArchiveException.php
@@ -15,4 +15,33 @@ namespace Joomla\Archive\Exception;
  */
 class UnknownArchiveException extends \InvalidArgumentException
 {
+	/**
+	 * The file type that couldn't be matched to a parser
+	 *
+	 * @type   string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $fileType = '';
+
+	/**
+	 * Constructor
+	 *
+	 * @param   string      $fileType  The Exception message to throw.
+	 * @param   string      $message   The Exception message to throw.
+	 * @param   int         $code      The Exception code.
+	 * @param   \Throwable  $previous  The previous throwable used for the exception chaining.
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function __construct($fileType, $message = '', $code = 0, \Throwable $previous = null)
+	{
+		$this->fileType = $fileType;
+
+		parent::__construct($message, $code, $previous);
+	}
+
+	public function getUnknownFileType(): string
+	{
+		return $this->fileType;
+	}
 }

--- a/src/Exception/UnknownArchiveException.php
+++ b/src/Exception/UnknownArchiveException.php
@@ -15,33 +15,4 @@ namespace Joomla\Archive\Exception;
  */
 class UnknownArchiveException extends \InvalidArgumentException
 {
-	/**
-	 * The file type that couldn't be matched to a parser
-	 *
-	 * @type   string
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected $fileType = '';
-
-	/**
-	 * Constructor
-	 *
-	 * @param   string      $fileType  The Exception message to throw.
-	 * @param   string      $message   The Exception message to throw.
-	 * @param   int         $code      The Exception code.
-	 * @param   \Throwable  $previous  The previous throwable used for the exception chaining.
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function __construct($fileType, $message = '', $code = 0, \Throwable $previous = null)
-	{
-		$this->fileType = $fileType;
-
-		parent::__construct($message, $code, $previous);
-	}
-
-	public function getUnknownFileType(): string
-	{
-		return $this->fileType;
-	}
 }

--- a/src/Exception/UnsupportedArchiveException.php
+++ b/src/Exception/UnsupportedArchiveException.php
@@ -15,4 +15,33 @@ namespace Joomla\Archive\Exception;
  */
 class UnsupportedArchiveException extends \InvalidArgumentException
 {
+	/**
+	 * The unsupported archive adapter name
+	 *
+	 * @type   string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $adapterType = '';
+
+	/**
+	 * Constructor
+	 *
+	 * @param   string       $adapterType  The unsupported adapter type.
+	 * @param   string       $message      The Exception message to throw.
+	 * @param   int          $code         The Exception code.
+	 * @param   ?\Throwable  $previous     The previous throwable used for the exception chaining.
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function __construct(string $adapterType, string $message = '', int $code = 0, ?\Throwable $previous = null)
+	{
+		$this->adapterType = $adapterType;
+
+		parent::__construct($message, $code, $previous);
+	}
+
+	public function getUnsupportedAdapterType(): string
+	{
+		return $this->adapterType;
+	}
 }

--- a/src/Exception/UnsupportedArchiveException.php
+++ b/src/Exception/UnsupportedArchiveException.php
@@ -40,6 +40,13 @@ class UnsupportedArchiveException extends \InvalidArgumentException
 		parent::__construct($message, $code, $previous);
 	}
 
+	/**
+	 * Gets the name of the adapter type that was unsupported
+	 *
+	 * @return  string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
 	public function getUnsupportedAdapterType(): string
 	{
 		return $this->adapterType;

--- a/src/Exception/UnsupportedArchiveException.php
+++ b/src/Exception/UnsupportedArchiveException.php
@@ -18,7 +18,7 @@ class UnsupportedArchiveException extends \InvalidArgumentException
 	/**
 	 * The unsupported archive adapter name
 	 *
-	 * @type   string
+	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $adapterType = '';


### PR DESCRIPTION
### Summary of Changes
Adds an additional parameter to the `UnsupportedArchiveException` constructor to allow us to give nicer translated messages in Joomla CMS

### Testing Instructions
Code Review

### Documentation Changes Required
Provided
