### PR TITLE
Increase requirements to only use joomla/filesystem 2.0 or above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^7.2.5",
-        "joomla/filesystem": "^1.3|^2.0"
+        "joomla/filesystem": "^2.0"
     },
     "require-dev": {
         "joomla/coding-standards": "^3.0@dev",


### PR DESCRIPTION
If we allow joomla/filesystem in version 1.x, we can never use a feature of joomla/filesystem from 2.0, which isn't also available in version 1.x. To not lock us in, we need to update all packages to only use dependencies from their line of major versions.
