### PR TITLE
Speed up archive unpacking performance

### DIFF
--- a/src/Gzip.php
+++ b/src/Gzip.php
@@ -162,7 +162,7 @@ class Gzip implements ExtractableInterface
     {
         // Gzipped file... unpack it first
         $position = 0;
-        $info     = @ unpack('CCM/CFLG/VTime/CXFL/COS', substr($this->data, $position + 2));
+        $info     = @ unpack('CCM/CFLG/VTime/CXFL/COS', substr($this->data, $position + 2, 8));
 
         if (!$info) {
             throw new \RuntimeException('Unable to decompress data.');

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -175,7 +175,7 @@ class Tar implements ExtractableInterface
         while ($position < \strlen($data)) {
             $info = @unpack(
                 'Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/Z8checksum/Ctypeflag/Z100link/Z6magic/Z2version/Z32uname/Z32gname/Z8devmajor/Z8devminor',
-                substr($data, $position)
+                substr($data, $position, 512)
             );
 
             /*

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -347,7 +347,7 @@ class Zip implements ExtractableInterface
             $endOfCentralDirectory = unpack(
                 'vNumberOfDisk/vNoOfDiskWithStartOfCentralDirectory/vNoOfCentralDirectoryEntriesOnDisk/' .
                 'vTotalCentralDirectoryEntries/VSizeOfCentralDirectory/VCentralDirectoryOffset/vCommentLength',
-                substr($data, $last + 4)
+                substr($data, $last + 4, 18)
             );
             $offset = $endOfCentralDirectory['CentralDirectoryOffset'];
         }
@@ -404,7 +404,7 @@ class Zip implements ExtractableInterface
                 throw new \RuntimeException('Invalid ZIP Data');
             }
 
-            $info                         = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength/vExtraLength', substr($data, $lfhStart + 8, 25));
+            $info                         = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength/vExtraLength', substr($data, $lfhStart + 8, 22));
             $name                         = substr($data, $lfhStart + 30, $info['Length']);
             $entries[$name]['_dataStart'] = $lfhStart + 30 + $info['Length'] + $info['ExtraLength'];
 


### PR DESCRIPTION
### Summary of Changes

Speed up archive unpacking performance by setting the correct size of the binary data for `unpack`.

### Testing Instructions

Run `phpunit` to check if all tests have passed.

### Documentation Changes Required

None.