### PR TITLE
Speed up archive unpacking performance

### DIFF
--- a/src/Gzip.php
+++ b/src/Gzip.php
@@ -162,7 +162,7 @@ class Gzip implements ExtractableInterface
     {
         // Gzipped file... unpack it first
         $position = 0;
-        $info     = @ unpack('CCM/CFLG/VTime/CXFL/COS', substr($this->data, $position + 2));
+        $info     = @ unpack('CCM/CFLG/VTime/CXFL/COS', $this->data, $position + 2);
 
         if (!$info) {
             throw new \RuntimeException('Unable to decompress data.');
@@ -171,7 +171,7 @@ class Gzip implements ExtractableInterface
         $position += 10;
 
         if ($info['FLG'] & self::FLAGS['FEXTRA']) {
-            $XLEN = unpack('vLength', substr($this->data, $position + 0, 2));
+            $XLEN = unpack('vLength', $this->data, $position);
             $XLEN = $XLEN['Length'];
             $position += $XLEN + 2;
         }
@@ -187,7 +187,7 @@ class Gzip implements ExtractableInterface
         }
 
         if ($info['FLG'] & self::FLAGS['FHCRC']) {
-            $hcrc = unpack('vCRC', substr($this->data, $position + 0, 2));
+            $hcrc = unpack('vCRC', $this->data, $position);
             $hcrc = $hcrc['CRC'];
             $position += 2;
         }

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -175,7 +175,8 @@ class Tar implements ExtractableInterface
         while ($position < \strlen($data)) {
             $info = @unpack(
                 'Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/Z8checksum/Ctypeflag/Z100link/Z6magic/Z2version/Z32uname/Z32gname/Z8devmajor/Z8devminor',
-                $data, $position
+                $data,
+                $position
             );
 
             /*

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -175,7 +175,7 @@ class Tar implements ExtractableInterface
         while ($position < \strlen($data)) {
             $info = @unpack(
                 'Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/Z8checksum/Ctypeflag/Z100link/Z6magic/Z2version/Z32uname/Z32gname/Z8devmajor/Z8devminor',
-                substr($data, $position)
+                $data, $position
             );
 
             /*

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -347,7 +347,7 @@ class Zip implements ExtractableInterface
             $endOfCentralDirectory = unpack(
                 'vNumberOfDisk/vNoOfDiskWithStartOfCentralDirectory/vNoOfCentralDirectoryEntriesOnDisk/' .
                 'vTotalCentralDirectoryEntries/VSizeOfCentralDirectory/VCentralDirectoryOffset/vCommentLength',
-                substr($data, $last + 4)
+                $data, $last + 4
             );
             $offset = $endOfCentralDirectory['CentralDirectoryOffset'];
         }
@@ -361,7 +361,7 @@ class Zip implements ExtractableInterface
                 throw new \RuntimeException('Invalid ZIP Data');
             }
 
-            $info = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength', substr($data, $fhStart + 10, 20));
+            $info = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength', $data, $fhStart + 10);
             $name = substr($data, $fhStart + 46, $info['Length']);
 
             $entries[$name] = [
@@ -390,7 +390,7 @@ class Zip implements ExtractableInterface
                 throw new \RuntimeException('Invalid ZIP data');
             }
 
-            $info = unpack('vInternal/VExternal/VOffset', substr($data, $fhStart + 36, 10));
+            $info = unpack('vInternal/VExternal/VOffset', $data, $fhStart + 36);
 
             $entries[$name]['type'] = ($info['Internal'] & 0x01) ? 'text' : 'binary';
             $entries[$name]['attr'] = (($info['External'] & 0x10) ? 'D' : '-') . (($info['External'] & 0x20) ? 'A' : '-')
@@ -404,7 +404,7 @@ class Zip implements ExtractableInterface
                 throw new \RuntimeException('Invalid ZIP Data');
             }
 
-            $info                         = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength/vExtraLength', substr($data, $lfhStart + 8, 25));
+            $info                         = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength/vExtraLength', $data, $lfhStart + 8);
             $name                         = substr($data, $lfhStart + 30, $info['Length']);
             $entries[$name]['_dataStart'] = $lfhStart + 30 + $info['Length'] + $info['ExtraLength'];
 

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -347,7 +347,8 @@ class Zip implements ExtractableInterface
             $endOfCentralDirectory = unpack(
                 'vNumberOfDisk/vNoOfDiskWithStartOfCentralDirectory/vNoOfCentralDirectoryEntriesOnDisk/' .
                 'vTotalCentralDirectoryEntries/VSizeOfCentralDirectory/VCentralDirectoryOffset/vCommentLength',
-                $data, $last + 4
+                $data,
+                $last + 4
             );
             $offset = $endOfCentralDirectory['CentralDirectoryOffset'];
         }


### PR DESCRIPTION
### Summary of Changes
Speed up archive unpacking performance by using `offset` argument in `unpack` (instead of `substr`).

### Testing Instructions
Run `phpunit` to check if all tests have passed.

### Documentation Changes Required
None.