### PR TITLE
[4.x] convert PHPUnit metadata doc-comment to attribute

### DIFF
--- a/Tests/ArchiveTest.php
+++ b/Tests/ArchiveTest.php
@@ -10,12 +10,23 @@ namespace Joomla\Archive\Tests;
 use Joomla\Archive\Archive;
 use Joomla\Archive\Exception\UnknownArchiveException;
 use Joomla\Archive\Exception\UnsupportedArchiveException;
-use Joomla\Archive\Zip as ArchiveZip;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
+use Joomla\Archive\Bzip2;
+use Joomla\Archive\Gzip;
+use Joomla\Archive\Tar;
+use Joomla\Archive\Zip;
 
 /**
  * Test class for Joomla\Archive\Archive.
  */
+#[CoversClass(Archive::class)]
+#[UsesClass(Bzip2::class)]
+#[UsesClass(Gzip::class)]
+#[UsesClass(Tar::class)]
+#[UsesClass(Zip::class)]
 class ArchiveTest extends ArchiveTestCase
 {
     /**
@@ -71,11 +82,7 @@ class ArchiveTest extends ArchiveTestCase
         ];
     }
 
-    /**
-     * @testdox  The Archive object is instantiated correctly
-     *
-     * @covers   Joomla\Archive\Archive
-     */
+    #[TestDox('The Archive object is instantiated correctly')]
     public function test__construct()
     {
         $options = ['tmp_path' => __DIR__];
@@ -86,19 +93,12 @@ class ArchiveTest extends ArchiveTestCase
     }
 
     /**
-     * @testdox  Archives can be extracted
-     *
      * @param   string   $filename           Name of the file to extract
      * @param   string   $adapterType        Type of adaptar that will be used
      * @param   string   $extractedFilename  Name of the file to extracted file
-     *
-     * @covers        Joomla\Archive\Archive
-     * @uses          Joomla\Archive\Bzip2
-     * @uses          Joomla\Archive\Gzip
-     * @uses          Joomla\Archive\Tar
-     * @uses          Joomla\Archive\Zip
      */
     #[DataProvider('dataExtractProvider')]
+    #[TestDox('Archives can be extracted')]
     public function testExtract($filename, $adapterType, $extractedFilename)
     {
         if (!is_writable($this->outputPath) || !is_writable($this->fixture->options['tmp_path'])) {
@@ -120,11 +120,7 @@ class ArchiveTest extends ArchiveTestCase
         @unlink($this->outputPath . "/$extractedFilename");
     }
 
-    /**
-     * @testdox  Extracting an unknown archive type throws an Exception
-     *
-     * @covers   Joomla\Archive\Archive
-     */
+    #[TestDox('Extracting an unknown archive type throws an Exception')]
     public function testExtractUnknown()
     {
         $this->expectException(UnknownArchiveException::class);
@@ -136,18 +132,11 @@ class ArchiveTest extends ArchiveTestCase
     }
 
     /**
-     * @testdox  Adapters can be retrieved
-     *
      * @param   string   $adapterType        Type of adapter to load
      * @param   boolean  $expectedException  Flag if an Exception is expected
-     *
-     * @covers        Joomla\Archive\Archive
-     * @uses          Joomla\Archive\Bzip2
-     * @uses          Joomla\Archive\Gzip
-     * @uses          Joomla\Archive\Tar
-     * @uses          Joomla\Archive\Zip
      */
     #[DataProvider('dataAdaptersProvider')]
+    #[TestDox('Adapters can be retrieved')]
     public function testGetAdapter($adapterType, $expectedException)
     {
         if ($expectedException) {
@@ -159,12 +148,7 @@ class ArchiveTest extends ArchiveTestCase
         $this->assertInstanceOf('Joomla\\Archive\\' . $adapterType, $adapter);
     }
 
-    /**
-     * @testdox  Adapters can be set to the Archive
-     *
-     * @covers   Joomla\Archive\Archive
-     * @uses     Joomla\Archive\Zip
-     */
+    #[TestDox('Adapters can be set to the Archive')]
     public function testSetAdapter()
     {
         $this->assertSame(
@@ -174,11 +158,7 @@ class ArchiveTest extends ArchiveTestCase
         );
     }
 
-    /**
-     * @testdox  Setting an unknown adapter throws an Exception
-     *
-     * @covers   Joomla\Archive\Archive
-     */
+    #[TestDox('Setting an unknown adapter throws an Exception')]
     public function testSetAdapterUnknownException()
     {
         $this->expectException(UnsupportedArchiveException::class);

--- a/Tests/ArchiveTest.php
+++ b/Tests/ArchiveTest.php
@@ -8,16 +8,16 @@
 namespace Joomla\Archive\Tests;
 
 use Joomla\Archive\Archive;
+use Joomla\Archive\Bzip2;
 use Joomla\Archive\Exception\UnknownArchiveException;
 use Joomla\Archive\Exception\UnsupportedArchiveException;
+use Joomla\Archive\Gzip;
+use Joomla\Archive\Tar;
+use Joomla\Archive\Zip;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
-use Joomla\Archive\Bzip2;
-use Joomla\Archive\Gzip;
-use Joomla\Archive\Tar;
-use Joomla\Archive\Zip;
 
 /**
  * Test class for Joomla\Archive\Archive.

--- a/Tests/Bzip2Test.php
+++ b/Tests/Bzip2Test.php
@@ -9,17 +9,16 @@ namespace Joomla\Archive\Tests;
 
 use Joomla\Archive\Bzip2 as ArchiveBzip2;
 use Joomla\Test\TestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test class for Joomla\Archive\Bzip2.
  */
+#[CoversClass(ArchiveBzip2::class)]
 class Bzip2Test extends ArchiveTestCase
 {
-    /**
-     * @testdox  The bzip2 adapter is instantiated correctly
-     *
-     * @covers   Joomla\Archive\Bzip2
-     */
+    #[TestDox('The bzip2 adapter is instantiated correctly')]
     public function test__construct()
     {
         $object = new ArchiveBzip2();
@@ -32,11 +31,7 @@ class Bzip2Test extends ArchiveTestCase
         $this->assertSame($options, TestHelper::getValue($object, 'options'));
     }
 
-    /**
-     * @testdox  An archive can be extracted
-     *
-     * @covers   Joomla\Archive\Bzip2
-     */
+    #[TestDox('An archive can be extracted')]
     public function testExtract()
     {
         if (!ArchiveBzip2::isSupported()) {
@@ -59,11 +54,7 @@ class Bzip2Test extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-bz2.png');
     }
 
-    /**
-     * @testdox  An archive can be extracted via streams
-     *
-     * @covers   Joomla\Archive\Bzip2
-     */
+    #[TestDox('An archive can be extracted via streams')]
     public function testExtractWithStreams()
     {
         $this->markTestSkipped('There is a bug, see https://bugs.php.net/bug.php?id=63195&edit=1');
@@ -87,11 +78,7 @@ class Bzip2Test extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-bz2.png');
     }
 
-    /**
-     * @testdox  The adapter detects if the environment is supported
-     *
-     * @covers   Joomla\Archive\Bzip2
-     */
+    #[TestDox('The adapter detects if the environment is supported')]
     public function testIsSupported()
     {
         $this->assertSame(

--- a/Tests/GzipTest.php
+++ b/Tests/GzipTest.php
@@ -9,17 +9,16 @@ namespace Joomla\Archive\Tests;
 
 use Joomla\Archive\Gzip as ArchiveGzip;
 use Joomla\Test\TestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test class for Joomla\Archive\Gzip.
  */
+#[CoversClass(ArchiveGzip::class)]
 class GzipTest extends ArchiveTestCase
 {
-    /**
-     * @testdox  The gzip adapter is instantiated correctly
-     *
-     * @covers   Joomla\Archive\Gzip
-     */
+    #[TestDox('The gzip adapter is instantiated correctly')]
     public function test__construct()
     {
         $object = new ArchiveGzip();
@@ -32,11 +31,7 @@ class GzipTest extends ArchiveTestCase
         $this->assertSame($options, TestHelper::getValue($object, 'options'));
     }
 
-    /**
-     * @testdox  An archive can be extracted
-     *
-     * @covers   Joomla\Archive\Gzip
-     */
+    #[TestDox('An archive can be extracted')]
     public function testExtract()
     {
         if (!ArchiveGzip::isSupported()) {
@@ -61,11 +56,7 @@ class GzipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-gz.png');
     }
 
-    /**
-     * @testdox  An archive can be extracted via streams
-     *
-     * @covers   Joomla\Archive\Gzip
-     */
+    #[TestDox('An archive can be extracted via streams')]
     public function testExtractWithStreams()
     {
         $this->markTestSkipped('There is a bug, see https://bugs.php.net/bug.php?id=63195&edit=1');
@@ -89,11 +80,7 @@ class GzipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-gz.png');
     }
 
-    /**
-     * @testdox  The adapter detects if the environment is supported
-     *
-     * @covers   Joomla\Archive\Gzip
-     */
+    #[TestDox('The adapter detects if the environment is supported')]
     public function testIsSupported()
     {
         $this->assertSame(
@@ -102,11 +89,7 @@ class GzipTest extends ArchiveTestCase
         );
     }
 
-    /**
-     * @testdox  The file position is detected
-     *
-     * @covers   Joomla\Archive\Gzip
-     */
+    #[TestDox('The file position is detected')]
     public function testGetFilePosition()
     {
         $object = new ArchiveGzip();

--- a/Tests/TarTest.php
+++ b/Tests/TarTest.php
@@ -9,17 +9,16 @@ namespace Joomla\Archive\Tests;
 
 use Joomla\Archive\Tar as ArchiveTar;
 use Joomla\Test\TestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test class for Joomla\Archive\Tar.
  */
+#[CoversClass(ArchiveTar::class)]
 class TarTest extends ArchiveTestCase
 {
-    /**
-     * @testdox  The tar adapter is instantiated correctly
-     *
-     * @covers   Joomla\Archive\Tar
-     */
+    #[TestDox('The tar adapter is instantiated correctly')]
     public function test__construct()
     {
         $object = new ArchiveTar();
@@ -32,11 +31,7 @@ class TarTest extends ArchiveTestCase
         $this->assertSame($options, TestHelper::getValue($object, 'options'));
     }
 
-    /**
-     * @testdox  An archive can be extracted
-     *
-     * @covers   Joomla\Archive\Tar
-     */
+    #[TestDox('An archive can be extracted')]
     public function testExtract()
     {
         if (!ArchiveTar::isSupported()) {
@@ -53,11 +48,7 @@ class TarTest extends ArchiveTestCase
         }
     }
 
-    /**
-     * @testdox  The adapter detects if the environment is supported
-     *
-     * @covers   Joomla\Archive\Tar
-     */
+    #[TestDox('The adapter detects if the environment is supported')]
     public function testIsSupported()
     {
         $this->assertTrue(ArchiveTar::isSupported());

--- a/Tests/ZipTest.php
+++ b/Tests/ZipTest.php
@@ -9,17 +9,17 @@ namespace Joomla\Archive\Tests;
 
 use Joomla\Archive\Zip as ArchiveZip;
 use Joomla\Test\TestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test class for Joomla\Archive\Zip.
  */
+#[CoversClass(ArchiveZip::class)]
 class ZipTest extends ArchiveTestCase
 {
-    /**
-     * @testdox  The zip adapter is instantiated correctly
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('The zip adapter is instantiated correctly')]
     public function test__construct()
     {
         $object = new ArchiveZip();
@@ -32,11 +32,7 @@ class ZipTest extends ArchiveTestCase
         $this->assertSame($options, TestHelper::getValue($object, 'options'));
     }
 
-    /**
-     * @testdox  An archive can be created
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('An archive can be created')]
     public function testCreate()
     {
         $object = new ArchiveZip();
@@ -61,11 +57,7 @@ class ZipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo.zip');
     }
 
-    /**
-     * @testdox  An archive can be extracted natively
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('An archive can be extracted natively')]
     public function testExtractNative()
     {
         if (!ArchiveZip::hasNativeSupport()) {
@@ -90,11 +82,7 @@ class ZipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-zip.png');
     }
 
-    /**
-     * @testdox  An archive can be extracted with the custom interface
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('An archive can be extracted with the custom interface')]
     public function testExtractCustom()
     {
         if (!ArchiveZip::isSupported()) {
@@ -119,11 +107,7 @@ class ZipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-zip.png');
     }
 
-    /**
-     * @testdox  An archive can be extracted
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('An archive can be extracted')]
     public function testExtract()
     {
         if (!ArchiveZip::isSupported()) {
@@ -148,11 +132,7 @@ class ZipTest extends ArchiveTestCase
         @unlink($this->outputPath . '/logo-zip.png');
     }
 
-    /**
-     * @testdox  If the archive cannot be found an Exception is thrown
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('If the archive cannot be found an Exception is thrown')]
     public function testExtractException()
     {
         $this->expectException(\RuntimeException::class);
@@ -165,11 +145,7 @@ class ZipTest extends ArchiveTestCase
         );
     }
 
-    /**
-     * @testdox  The adapter detects if the environment has native support
-     *
-     * @covers   Joomla\Archive\Zip::hasNativeSupport
-     */
+    #[TestDox('The adapter detects if the environment has native support')]
     public function testHasNativeSupport()
     {
         $this->assertEquals(
@@ -178,12 +154,8 @@ class ZipTest extends ArchiveTestCase
         );
     }
 
-    /**
-     * @testdox  The adapter detects if the environment is supported
-     *
-     * @covers   Joomla\Archive\Zip
-     * @depends  testHasNativeSupport
-     */
+    #[Depends('testHasNativeSupport')]
+    #[TestDox('The adapter detects if the environment is supported')]
     public function testIsSupported()
     {
         $this->assertEquals(
@@ -192,11 +164,7 @@ class ZipTest extends ArchiveTestCase
         );
     }
 
-    /**
-     * @testdox  The adapter correctly checks ZIP data
-     *
-     * @covers   Joomla\Archive\Zip
-     */
+    #[TestDox('The adapter correctly checks ZIP data')]
     public function testCheckZipData()
     {
         $object = new ArchiveZip();


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

missing migration from convert metadata doc-comments to attributes

### Testing Instructions

run `vendor/bin/phpunit --testdox`

### Documentation Changes Required

no